### PR TITLE
GitHub: Add an initial CODEOWNERS file to auto-assign reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fviernau @mnonnenmacher @sschuberth @tsteenbe


### PR DESCRIPTION
See https://help.github.com/en/articles/about-code-owners.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>