### PR TITLE
Add meeting minutes for the TSC meeting on 2025-01-17

### DIFF
--- a/minutes/2025-01-17.md
+++ b/minutes/2025-01-17.md
@@ -1,0 +1,496 @@
+## **ORT TSC Meeting \- 2025/01/17 11:00 CET – Transcript**
+
+# **Attendees**
+
+Frank Viernau, Marcel Bochtler, Martin, Sebastian Schuberth, Sebastian Schuberth's Presentation, Thomas Steenbergen
+
+# **Transcript**
+
+Sebastian Schuberth: Transcription will start soon. So, is there a way to show this? This call is being let's just trust it and hope that it works. so it's good that we're talking in English because transcription only works in English Okay, let's get started. unfortunately I had very little time to prepare for this meeting.
+
+Sebastian Schuberth: So just this morning I was trying to assemble some of the arguments. So as a reminder the main topic for this meeting is that I would like us to consider moving or as a project from the Linux Foundation to the Eclipse Foundation which has been a topic we have been occasionally talking about several times over the years.  But this time I would really like to formally discuss and vote about this and take a decision here. So you should see my screen here.
+
+Sebastian Schuberth: So I created issue 35 on our or governance issue tracker and my personal main reasons there might be other reasons maybe from your side but whatever are listed here. So I tried to state some things that bother me with how things work out at the Linux Foundation currently.  So one point is a lack of activity. So since the inception in 2019, the automated compliance tooling working group as part of the Linux foundation has not really shown any significant activity. So there was no posting on the news side besides the announcement of turn 2.0
+
+Sebastian Schuberth: O which by now is anyway a dead project and it was also not able to attract any additional members beside the founding members. So act as a working group as a whole at least to the outside to me is completely in limbo state. There is nothing happening. Also when trying to approach the Linux Foundation about this I see that there is a lack of support.  So, there is by the way one thing that I missed to list here. I will do that later on. So in general Linux Foundation or ACT have never proactively reached out to any of us as far as I know to ask how to support in any way.
+
+Sebastian Schuberth: There was no funding, no help in marketing, no proactive promotion through the working group, no assistance in community building, no providing of infrastructure or anything like that. And whenever I try to reach out to Kate and others about this via email, my emails simply have not been answered at all.  So there was not even something like sorry I don't have time currently come back to me in a month. I tried several times and I was completely ignored.
+
+Sebastian Schuberth: The only person I was able to talk about this by the way was Milco Boom who is the former CEO of Endo in Berlin and by now working for the Linux Foundation Europe and that's why I occasionally meet him in person in Berlin at the backstage and so on.  So he's my only contact that is replying to me at the Linux Foundation about this basically which leads me to a general topic of problems in communication. So there is LF Europe by now yes but clearly remains US centric in everything that it does.
+
+Sebastian Schuberth: So it reflects in meeting times that are more suitable for the US and other things and also there are internal sort of communication problems. So I have to admit I have very rarely attended any of the act tech meetings. but although also other people that were attending those meetings on a more regular basis were saying that they completely make misuse of these meetings. It's not about vendor neutral automated compliance tooling. It's more or less an SPDX promotion meeting. So they were misusing this meetings to talk about SPDX tooling specifically.
+
+### 00:05:00
+
+Sebastian Schuberth: They wanted to enrich the ecosystem for SPDX tooling which is not in my view the purpose of the working group and what really offended me is that I have learned now from at least two parties that even internally and LF on its own doesn't seem to know about ACT and tools like  report. So there were people from companies who are LF member organizations and they had problems in automating their compliance checks and they were reaching out to the LF and asking hey do you have a solution there and they were saying no we do have some paid tools apparently but you cannot use them because we don't have the right number of seats.
+
+Sebastian Schuberth: but there is this thing currently being developed which is called scaffold and this is something that I heard for the first time. I've linked it here. Apparently it's some wrapper around fossology and this is quite new as you can see things have been submitted three weeks ago and this is now the tool that Linux Foundation is promoting for the matter of automating their compliance checks.  So no one was even mentioning or to them as an alternative. So yeah in my view re really bad. next topic is no good technology fit. So yeah like I wrote here let's face it is about Linux and related ecosystems.
+
+Sebastian Schuberth: So that means the Linux kernel embedded systems containers and this kind of stuff which is not technology was originally designed for. I know we on and off have these discussions about how and if u to integrate container analysis or docker file or image analysis into but that's not what or was made for.  art is about application compliance for managed enterprise software that use modern build systems. That's the main target. It's not for ensuring compliance of Linux distributions like bit yto builds or container compliance.
+
+Sebastian Schuberth: While we could of course think about all of this and do some hacks to support this in some way, it's not the primary target audience or as a result Linux Foundation itself has no inherent interest to use or they just see it as one of the many other projects that they're hosting, but they have no intention to use or themselves internally.  And the fact that this scaffold project is just underlining that. Also I think from a spirit perspective and thinking and community perspective Linux Foundation does not seem to be a good fit. these people they like low-level Linux stuff.
+
+Sebastian Schuberth: they like SPDX as a file format and just from a mental perspective, I don't see this to be a good fit. So that's my thinking so far about sort of the cons against the Linux Foundation. I'd like to take a short break here.
+
+Sebastian Schuberth: any thoughts, questions, additions? Of course, you are also free to highlight any pros if you see some about being part of the Linux Foundation or the automated compliance tooling group. yeah, just taking a break here before I proceed to the next point.
+
+Martin: I cannot add anything.
+
+Thomas Steenbergen: What's up, Frank? …
+
+Marcel Bochtler: I've also never communicated with the Linux Foundation and also didn't see any active participation in the old project.
+
+Thomas Steenbergen: so I answer because I can probably give answers on. So, yes, ACT is a sleeping zombie. but there is still funding in there and there's currently discussions what to do with it. if I email LF because I know the people by myself I get answers literally within hours next day at worst. it's not a problem at all because I know the people and I've met them. L is a big monster. It has a thousand plus projects. So I wonder who you emailed about this.
+
+### 00:10:00
+
+Sebastian Schuberth: I was directly communicating with Kate Stewart and…
+
+Sebastian Schuberth: Merkel Boom. those were my primary contacts.
+
+Thomas Steenbergen: Yeah, Miracle has nothing to do.
+
+Thomas Steenbergen: He's out of Europe. So, we won't fall under.
+
+Sebastian Schuberth: McDonald, but he's just a legal guy, right?
+
+Thomas Steenbergen: We fall under out of project. So, the right person to talk to Kate is usually busy for this kind of stuff. It's my go. That's who we actually report to. No, he is also the GM of projects. So, basically, we fall officially under Mike Dolan. we have shown there. Kate is our steward on their act, but it said because Kate is overwhelmed, it's usually. So if I need to get stuff done, I know it's said I have a long relationship with these people, so I can get through relatively easy. I have most of them also on other platforms. I have their phone numbers. Just again, I've worked with them for years and I've met them regularly. So that's all about the relationships here.
+
+Thomas Steenbergen: or if you want to get stuff done. it is actually in our charter.
+
+Martin: Yeah, I mean that shows trust just a comment on this part.
+
+Martin: I mean that shows that the organization is fundamentally broken, right? This information should be documented publicly and available if it's an open source foundation. It cannot be that as a member project, you just cannot figure out who's responsible for you and you could talk to The name of the person.
+
+Thomas Steenbergen: In our charter. It's literally not the name of the document, but it's the name of on the bottom who we fall under. And if you look under leadership, you'll literally see his name pop up that he is responsible for us.
+
+Martin: Okay. Yeah. still…
+
+Thomas Steenbergen: It's follow the entity and you'll see that he responds to us and he is also the one that maintains also.
+
+Thomas Steenbergen: Just if you are under you it's the same with most other foundations.
+
+Martin: still it should be not in some wicket repository we maintain that's not how an organization should work yeah still that's my comment
+
+Thomas Steenbergen: You just have to ask because I handled the moving to the foundation, I know who our contact person is. Yeah. So, Yes. and it is Yeah.
+
+Thomas Steenbergen: meetings are like I know LF is not always doing all the stuff and one left side doesn't know what the right side is doing I am actually aware of scaffold actually have a meeting with the car and basically they're not only integrating fology or will also be there it's actually not a tool around philosology but it's a tool around trippy yeah I know that politics it's to get the funding and…
+
+Sebastian Schuberth: It's a framework for instrumenting forology scans.
+
+Thomas Steenbergen: A lot of the ALF members are still under facility and the person's there is also using facility again the way how you communicate things to get projects accepted and all the other stuff. it's how you communicate. So I said we have promotion marketing at all of the events for my life.
+
+Thomas Steenbergen: Yes, and we have access to alex we don't use most of the stuff because we are not ready in my view but said for the community days we get support from for the events that I'm now organizing related to or I get support from so is we're now having a whole discussion on the event that we're organizing in Stoutgart
+
+Thomas Steenbergen: There I at least get 500 from the LF side to pay for this and all the LF infrastructure. So, we do get this. It does not necessarily come off ACT and I mostly get it then via the open chain side because that's how Marcel and I mostly work.
+
+Thomas Steenbergen: But yeah, we do get funding mark. We don't use marketing either because I said the biggest problem that we have is on boarding and our documentation. This is awesome.
+
+Sebastian Schuberth: No, I don't think that the lack of documentation is the reason…
+
+Sebastian Schuberth: why we are not being promoted inside LF or why we lack contributors and also if you say that we do get money then we in this case is not community but the open chain community just because we happen to be part of this open chain event yes indirectly we somehow benefit of this but LF would be sponsoring the event even…
+
+Sebastian Schuberth: or was not an LF project right so it's not related to or…
+
+Thomas Steenbergen: But this port is not set up to receive money.
+
+Sebastian Schuberth: being an project I think you're swapping the cause and…
+
+Thomas Steenbergen: So we do it via the other side.
+
+### 00:15:00
+
+Sebastian Schuberth: and the result here. So, I don't think the reason of a lack of funding from LF is because we didn't set up or to receive money or so or we didn't activate GitHub sponsors or so. I can explain this better maybe when I come to the next point about the pros that I see on the Eclipse Foundation side because now when by the start of this year double open became also an Eclipse Foundation membership organization.
+
+Sebastian Schuberth: It was a completely different onboarding experience about how their marketing teams were reaching out and asking how to support and blah blah. And maybe Martin and others can share similar stories about when you're not leading an Eclipse Foundation membership organization but leading an Eclipse Foundation project. that's…
+
+Thomas Steenbergen: Again you are a paid member. That's the same on boarding you get if you do a paid explanation project.
+
+Sebastian Schuberth: why I say that's…
+
+Thomas Steenbergen: That's the difference.
+
+Sebastian Schuberth: why I said I don't want to compare apples and oranges and that's why I said let's also have maybe Martin say on his experience of onboarding a project from a community perspective and not from the perspective of a paying member organization. that doesn't matter in this case.
+
+Thomas Steenbergen: but he works for a paying member.
+
+Sebastian Schuberth: It's about bringing an open-source project to the Eclipse Foundation. So yes,…
+
+Thomas Steenbergen: We just brought to the Eclipse Foundation by Bosch who's a board member. Forget BCH is a board member.
+
+Sebastian Schuberth: But the onboarding experience would have been exactly the same if it was not established by a board member. They have clear processes about this and the rules and conditions are the same for anyone if you bring in a project to the Eclipse Organization no matter whether you're backed up or…
+
+Sebastian Schuberth: coming from a member organization or not.
+
+Martin: Yeah, there's not really something to compare…
+
+Martin: because there's not something to compare to because there was no such experience with the Linux Foundation because there was nothing, right? They don't provide any infrastructure or anything. The only one who talked to them was Thomas. But I never got into contact with anyone from there because we do not use any of the services. So that's why it's not really a comparison because I compared to nothing but experience with Eclipse Foundation for the onboarding of the project was pretty good. So they have processes defined of course.
+
+Martin: So you have to follow some rules while with LF we do not have to follow anything it seems except for maybe the charter but I mean technically there's nothing to follow how to set up anything in our repository or so and compared to that Linux Foundation provides infrastructure and tooling and support and their technical support is pretty good.  So I opened tickets several times since we onboarded the project and the response time was always very fast and they were very active in trying to solve the issues we had. So yeah my experience with this project on boarding was overall very good.
+
+Martin: Also, I like that they do care about some quality aspects of their projects they do not want their projects to all have their own release type or so, but they really define what they expect their projects to do when they make releases and have some documentation also for quality metrics that should be met by the projects. So, I don't see nothing like that ever happened with the Linux Foundation for our project.
+
+Thomas Steenbergen: That is actually coming.
+
+Martin: But I think that's enough to say. I don't want to go into technical details.
+
+Sebastian Schuberth: Okay, as we're anyway already talking a bit about the pros of the Eclipse Foundation as I and… others see it. let's go through the section now as So in general my personal feeling is that me personally but also we as a community maintain a better relationship with the Eclipse Foundation in general.  The Eclipse Foundation has been interested right from the start when they learned about ORT to take ORT into use up to the point where they considered to replace their internal CQ processes for onboarding and checking Eclipse Foundation projects on a regular basis with tooling.
+
+Sebastian Schuberth: 
+
+### 00:20:00
+
+Sebastian Schuberth: And as far as I know both Thomas was involved somehow in terms of consulting. I was involved when I was a freelancer in terms of custom development and coll collaboration with Boris from the Eclipse Foundation who did some proof of concepts there. unfortunately back then it failed mostly due to a lack of scalability of the or CLI tooling. But that is something that is exactly being resolved with server. in general, I feel that collaboration with Eclipse Foundation is much easier. they are much more EU based and the biggest open source organization in Europe. Communicating with them is much easier due to the same time zones mostly. they are much more responsive and reactive no matter who I'm reach out to.
+
+Sebastian Schuberth: So there is no one like a Kate that just ignores me for a month and not even saying sorry you're talking to the wrong person please go to Mike Dolan or  So that is my experience here and since the Eclipse Foundation has an inherent interest in or for its own use that alone is a very very very strong argument for me to be the better foundation because if they have an inherent interest they will also care about developing it further growing the community and stuff like that.
+
+Sebastian Schuberth: the odd server already is an Eclipse Foundation project. So, that's also an argument for me to not split the communities and the foundations here, but consolidate things that belong together at the same place like Martin just mentioned, good experience with project onboarding and technical support.  And yes, since the beginning of this year, double open just Bosch is an Eclipse Foundation member organization. So in all to me strong arguments here regarding the collaboration but also on the technology level. I feel that the Eclipse Foundation is a much better fit for art as a tool.
+
+Sebastian Schuberth: Many Eclipse Foundation projects are in fact coming from the Java JVM community. So the chance to attract the developers and contributors from the Eclipse Foundation in my view is much higher than attracting people from LF projects contribute toward. they simply come from totally different technology domains.  So yeah, I think I missed a few points here because I had to stop writing shortly before this meeting, but yeah, those are the pros that see. is there anything you would like to add comment on?
+
+Thomas Steenbergen: said Eclipse would be just narrowing the potential pool of echunis. I said I'm now working with fenos running in the phenos foundation which is people don't know that that's the financial services branch aka banks because I've been talking to a certain large American bank that wants to use or I've been talking to them for also other banks but I said the problem is on boarding and the government support that's why the last one it failed. said I'm unfortunately not allowed to say which bank. I said I did one American bank lost here. I did the UK bank. and now I'm talking to another American bank again. and now we're doing the proof case in Fenos to get Fenos to users. They actually have a lot of Java projects LF. They're much more than you think. but they're not under the links foundation. They're under the sub foundations.
+
+Thomas Steenbergen: So out of energy phenos and there are many more have tons of Java projects they're generating but is said the difference is just a different setup the setup is like a network of foundations you have multiple sub foundations that do things which all have their own control and their own peace of mind there's not one central control from that's how it's set up to scale and to basically  let projects choose whatever fits best to their needs. And actually I don't mind that actually because I had discussion with Marshall about old server whether it's under Eclipse and I actually thought it would be great to have it under dips so that we can actually dip both worlds. So we can take from Eclipse we can still talk to that side and we have also on the left side and we can fly both banners which basically
+
+### 00:25:00
+
+Thomas Steenbergen: No, but now both foundations have a stick have mistaken it.
+
+Sebastian Schuberth: foundations is a good thing, but that's what we did for the past years and I have to say that was not good. So we tried and we lost sort of Martin is raising his hand.
+
+Sebastian Schuberth: Open queue. What does it mean?
+
+Martin: Yes, I wanted to say I didn't understand Thomas by…
+
+Martin: what you said as it was an argument for how the L foundation benefits the project because it sounds like yes okay it's a means for you to elevate your own career and use art as a leverage and maybe this context from the foundation helped you but I don't see how that somehow comes back to the project in the form of contributions or thing.
+
+Thomas Steenbergen: industry. That's also largely the base of what you see as Eclipse members. We kind of are running out of funding members and all that other stuff. I'm organizing this event in Stuttgart to see what else we can get to get more organized in Germany. basically with all the noise that's happening in the space with all of the other stuff and SEA tools wants to grow and become more successful we need to change things up and we need to go to new industries that's why I worked with Alander to work into LF energy that's why Alander now uses energy now it goes to RTE the only problem that we have is still that we have tons of or users that unfortunately  don't come to the community and communicate back.
+
+Thomas Steenbergen: It's very annoying thing and they go to unfortunately the consulting from god this was the guy again the Hermine project how are these guys are kind of cold so they basically have French consultants supporting them or they have Accenture doing or support so they don't connect back which is a freaking annoying pisses me off like hell but again we already readily were not set up as having commercial support or make commercial support choices clarity or some organizations  don't understand this stuff.
+
+Thomas Steenbergen: Now we have both sides. we can set or is being used by other for us to grow. We need to go to other industries.
+
+Thomas Steenbergen: We need to go to get more broad appeal instead of saying just a German project. And if we come in my case an eclipse project it will be seen as it's a B open source project and that's it.
+
+Sebastian Schuberth: I don't think there is a risk like that to or…
+
+Sebastian Schuberth: or server as a Bosch exclusive project that just happens to be hosted at the Eclipse Foundation  On the contrary, I mean there are two items that I missed to list here. So you were mentioning we should do closer collaboration with the German automotive industry and yes yes we should and this actually matches heavily the Eclipse Foundation softwaredefined vehicle working groups to which we already have good relationships via former Bosch and it has members Anska and so on.
+
+Sebastian Schuberth: So they are heavily promoting or inside of SDV as well for the car manufacturer OEM and automotive industry in general. And another thing is that it slipped my mind again. What was it?  Yeah, something I added here meanwhile was that I simply feel better with Eclipse Foundation because in terms of esbombs it's a completely neutral ground right so we are not associated with an organization that is also pushing SPDX only for example and clearly not playing fair when it comes to competing with other formats like cyclone DX there has been this dispute between those communities and
+
+Sebastian Schuberth: working groups about SPDX just bluntly copying code without giving credits from the cyclone X community which is ridiculous right for a working group that is about open source compliance and so  So to me I mean those are simply not people I want to work with people who do stuff like this I don't want to work with them open app is also Linux foundation related  Yeah, sure.
+
+Thomas Steenbergen: But there you see again the different parts because open and zap is all mostly cyclone DX kind. So is that LF has this contradictions? This just happens. Yeah. And that's where Cyclone DX rules. it's funny if it's contradictions, but that's how it is. Again, different parts of our life do different things and they're not always aligned.
+
+### 00:30:00
+
+Sebastian Schuberth: Linux Foundation is big and it's probably too big and I don't doubt that in such a big organization or foundation there are also Java projects and there are also projects that use Cyclone DX but it's the exception.  If you have to go by a rule of thumb, then at least my clear feeling is Eclipse Foundation is a better fit technology-wise and otherwise. there is I remember again what's the point here.
+
+Sebastian Schuberth: So this is maybe a point that is a bit subjective to myself but at least double open and nextb slashabout code will work closely with as part of octed u project as part of the let's  say you run the octed project. So just fixing some typos here.
+
+Sebastian Schuberth: So that said, of course there are maybe some organizational obstacles. if we ever wanted to decide to move foundations, I just want to be transparent about these potent potential obstacles. Yeah. and one of them is things like transferring the or trade mark from LF to EF.
+
+Sebastian Schuberth: So this is to be honest something that was not completely clear to me when we u entered the Linux Foundation but it apparently is so that not we as a community own the unregistered trademark of but the Linux Foundation does. and it could be a problem mostly out of political reasons to ask the Linux Foundation to be willing to transfer this copyright from LF to EF.
+
+Sebastian Schuberth: I've already discussed this with a few people and they signaled to support us if we wanted to do that. They signaled that they would guide us and support us in the legal process to get this done. So, it's not impossible. It's probably something where we need to expect the LF to not be very cooperative. So this is just for transparency something I wanted to share here.
+
+Thomas Steenbergen: So I actually already spoke about LF with this. So I know actually what the problem procedure is for this…
+
+Sebastian Schuberth: Okay, that's good.
+
+Thomas Steenbergen: because again I have responds to my email. So I asked the right person I asked who so first of all we as TS sorry TSC are by our current charter not empowered to move the project be clear the current charter remember my words current charter so…
+
+Sebastian Schuberth: Yeah. Yeah. Yeah. True, true. But
+
+Thomas Steenbergen: how the process works is that by the charter 2/3
+
+Thomas Steenbergen: thirds in this case four out of the five TSC members would need to vote in front of a move to change the charter to enable such a move then the original owner in this case here technologies then actually LF projects technically need to approve it's Mike Goland in this case needs to approve because that's by our chart if you go to our charter  Maybe if open up the charter is really in our charter. It's the last line in our charter. So then LF needs to approve such a move which by their processed carter would need to go back to here because how it works on a neutral home and a pitch has exactly the same role. If a project stops or gets transferred the original code owner the original donator needs to be asked for their approval. that's just legally how it works.
+
+### 00:35:00
+
+Thomas Steenbergen: we are part again the legal home is an LLC. It's created it's not only the trademark it's all IP. So you're talking about copyrights, trademark patents. god there's more s\*\*\* there. There's more stuff that's basically all shaded and all of that has been transferred by here. So here needs to basically be informed and ask for it. I doubt that here will do it. I'm already reached out this morning basically to get a line open. I know who to talk to it. But that's how it works. So the original donators need to be asked first for their approval. Again, because I did the transfer to LF, I'm very know how it works and I have all of the paperwork, but the paperwork was here paperwork originally.
+
+Thomas Steenbergen: So I couldn't take a look. But yeah, I know all the documents that are related to this.
+
+Martin: To clarify that you have understood correctly is that you doubt here will approve this or…
+
+Martin: or what was it?
+
+Thomas Steenbergen: Yeah. Yeah. Because here…
+
+Martin: Why do you think this? And why should
+
+Thomas Steenbergen: because that has to do with the original reasons why here moved it on to LF and not on the Eclipse. the business reasons are probably still the same and that here is a member of ALF and not a member of Eclipse and they have their own business reasons which I'm probably under my NADA not fully at liberty do to say all discuss stuff because this were leadership discussions that I was part of but yeah the business case for here to move things to Eclipse was simply not there
+
+Thomas Steenbergen: And I don't see there. I will try checking now because again I have to still write lies with layers and get it in writing for them. because that's what they will ask for. but yeah I said you can read it in our charter. It's actually according to our charter. It's literally in the charter. You read is that LF will have to ask your LF itself.  I don't know what's well read all the documents with this that I already got it in. I can also arrange the next step and just talk to get a call with Mike Dolan set up so you can hear it from himself.
+
+Sebastian Schuberth: Yeah, before we do any of this I Of course, first to lay to get some initial feedback from all of you. whether you think we should take this effort or not. I mean if the majority of us says no we don't want to do this at all then of course we don't need any meetings with Mike Dolan or whoever and don't take the effort to change the trader anything like that.  So I think that that can come first just to get a feeling of the intention of the rest of the TSC. I mean you've heard my opinion now and I've been pretty clear about it but I'm very unclear about Frank's and also maybe Marcel's opinion here. So that would for me be the first step. Just get a feeling of your feelings.
+
+Frank Viernau: Let's say if we move to Eclipse what impact does it have on the process to become let's say a committer or having a say on the project like becoming a TSC member or are there even people on the board…
+
+Frank Viernau: who have influence on the direction of the project and what would be the impact of the Move.
+
+Martin: So in Eclipse Foundation they have defined roles and…
+
+Martin: projects where you have committers and A project lead is not a technical role. it's an organizational role. but it's not a person who can make technical decisions. So it's not like a the project lead is more like for organizing the project let's say and the committers are people with right access to the project and any kind of this decisions they have to be made if in question by some kind of vote.
+
+### 00:40:00
+
+Martin: So the community has to agree, the committers have to agree and then there's a formal process to become a committer where any existing committer must start a vote on the Eclipse website. They have a tool for that. And then all committers have to vote or can vote on approving the new committer within some time frame. I think it's one or two weeks. I think one week and then there's also a process to remove committers.  I think that's one of the things that the project lead has to remove inactive committers after a while or so and they have an extensive documentation on these processes in the project handbook. So that is not important really required to be a committer.
+
+Frank Viernau: No, no,…
+
+Martin: That is the committers.
+
+Frank Viernau: not just committer but I mean this different kind of ros you have which have a say on the direction of the project. is it for some of these? Yeah.
+
+Martin: So the Eclipse foundation is not that there are someone from the Eclipse Foundation coming to the project and saying you have to implement this or that. What they define is yeah not
+
+Sebastian Schuberth: answer is you don't have any benefits sort of in terms of contributing or leading a project if you come not come from an Eclipse membership organization
+
+Martin: Yeah. Yeah.
+
+Martin: They especially emphasize that your employer is not relevant for your status as a committer or project lead. So for example, what they especially do not want is that someone who is starting to work for if we would have a new team member at Bosch that they just say to make it easier for you to contribute we just make you a committer of the project. So that's something they describe that's not how it should work but only based on people should be added as committers.
+
+Martin: If you propose someone to become a new permitter, you have to provide a reason why they should and you have to also list what were the contributions to the project. So that also means if you leave the company, it does not mean you lose your committer status because these roles at Eclipse Foundation should be independent from your employer.  Does that answer your question, Frank? What do we have more?
+
+Frank Viernau: Let's say if you work for an employer who is not member of the Eclipse Foundation, would you have any disadvantage residing from this move as an art contributor?
+
+Sebastian Schuberth: No, no,…
+
+Martin: No, I don't see any.
+
+Frank Viernau: Let's say
+
+Sebastian Schuberth: you don't have any disadvantage.
+
+Martin: Yeah, because the rights you have in the project are purely based on you being a committer and have nothing to do with your employer.
+
+Thomas Steenbergen: So in the consultancy case for instance, if I commit under my own TB found, everything's fine because I'm an individual committer. But if I say what Frank is now doing when he now has to contribute two or under this legal identities, then Z might not be an Eclipse member or a commiter member. So then there is a problem especially if there is we have to commit on the EM is also the same rules.  we have to commit under as working for that company and if that me.
+
+Thomas Steenbergen: So this is the thing as an individual Frank and I or anybody else we can commit to Eclipse projects once we have a right but on our personal title right but if I commit on behalf of a legal entity which is quite common in the consultancing business then we have to become a member that's the difference with Eclipse we have to become a member because otherwise we cannot commit on behalf of that that entity would have to commit under myself basically on the personal title…
+
+### 00:45:00
+
+Thomas Steenbergen: which is not allowed under the employment contract.
+
+Sebastian Schuberth: That's not true, Thomas. I mean I have committed in the name of double open before double open was an Eclipse Foundation member and it was not a problem at all…
+
+Thomas Steenbergen: Again the project might act like that but my understanding of the text actually meant as an individual member it might get accepted but legally that's not the membership agreement how I read the membership agreement that's why we should clarify with Eclipse No,…
+
+Sebastian Schuberth: then I think you're misreading it. So Eclipse Foundation would be stupid, If they would decline contributions, freely made contributions from companies just because they are not paying Eclipse Foundation members. I mean that's trading yourself,…
+
+Thomas Steenbergen: no, but they
+
+Sebastian Schuberth: And that's not my understanding of the policy and in practice that's not what I was experiencing.
+
+Thomas Steenbergen: It's what I understand from this and that's why we can clarify that you can commit but you would have to be a separate committer because I said individual drive by commits no
+
+Sebastian Schuberth: we can clarify on that of course beforehand, right? So, I can reach out to whomever and get a definite answer about this topic. And yeah, of course, there are a few more things we need to clarify anyway beforehand.  So, maybe I can list this under potential obstacles.
+
+Thomas Steenbergen: But if you want to do structural things always clips you have to become a member that's what we always got from here in the past and…
+
+Thomas Steenbergen: I don't think the change whenever we talk to from here to do things yes we can do became become a member also for the main list and all the other stuff individually yes I could do it but if I did things out
+
+Sebastian Schuberth: Yeah. Yeah,…
+
+Sebastian Schuberth: I understand what you're saying. But like I said, I did commit on behalf of not myself and not myself as a freelancer. I did commit on behalf of double open as a company,…
+
+Frank Viernau: And so could they also have voted you to become a member of the TSC while not being member of the eclipse. Okay.
+
+Sebastian Schuberth: And there was no question problem process- legal wise at all with my contributions to the old server which is an Eclipse Foundation project.
+
+Sebastian Schuberth: So there is no TSC at Eclipse Foundation project. So that's why I'm a little bit confused now. But PMC is not…
+
+Thomas Steenbergen: the P PMC or…
+
+Thomas Steenbergen: is it PMC I think it's called
+
+Sebastian Schuberth: what you have on an individual project level, right? there is a thing an entity called PMC. Yes. But that's not specific to a single Eclipse Foundation project as far as I know. But the PMC group is responsible for multiple Eclipse Foundation projects. Right Martin?
+
+Martin: That's each of those projects have one project management committee and these are for example the people that also have to approve a new committ. So if the project voted on a new committ then in the end when the vote is done one member of the project management committee has to approve this as well. but yeah that's not part of the individual project but that's on a higher organizational level. So no one in our side is member of the PMC.
+
+Thomas Steenbergen: how this works there's committing members and then there is contributing members so as a committed members you cannot join main list it seems I cannot join working groups I understand they cannot vote in the general assembly…
+
+Sebastian Schuberth: Yes. Yeah.
+
+Thomas Steenbergen: how Eclipse will turn that's all perfectly fine No,…
+
+### 00:50:00
+
+Sebastian Schuberth: But this page is not for individuals, that's also not for individuals.
+
+Thomas Steenbergen: but that's the bottom one. Committing members. That's the bottom one.
+
+Sebastian Schuberth: The wording is a little bit misleading. Commiter member does not refer to individuals as far as I know.
+
+Sebastian Schuberth: It's a membership level for organizations.
+
+Frank Viernau: But the first sentence speaks of individual committers or…
+
+Frank Viernau: under the committer member section in the link.
+
+Sebastian Schuberth: 
+
+Sebastian Schuberth: Where are you Maybe I should open this in the room. So commission yeah this whole page is about membership levels for organizations and…
+
+Martin: Yeah, I think that's really not what it does not mean individual persons as a commitment, but because the rest of the text doesn't make sense if this is what I spent.
+
+Sebastian Schuberth: I went through just this year or late last year for to become a contributing member with double open as a company. So I've read through all of this and these are just membership levels for organizations.
+
+Sebastian Schuberth: The wording is not good. I agree. But this whole page is not for individuals.
+
+Martin: So also I think all these things here like being able to join some of the working groups also that's all related to be participating to the Eclipse Foundation itself not had nothing to do with contributing to a project.
+
+Martin: So if you want to be on the board of directors of the Eclipse Foundation then okay your company has to be an Eclipse Foundation member
+
+Sebastian Schuberth: Yeah. …
+
+Sebastian Schuberth: we are unfortunately reaching the official end of our meeting. I don't mind overrunning a few minutes, but I don't know about you, but I would like to ask at this point in time, do you all feel comfortable and in a position to vote in this post that I've written meanwhile? So, this is just to get an initial feeling about whether we should proceed with this idea and proposal further.
+
+Sebastian Schuberth: Is there any one of you saying no sorry I cannot say anything about it and I also don't want to abstain from the voting which is something I've listed here too but I don't know you want to wait clarify some things first make up your mind I don't know otherwise I would really like to at least proceed with this initial feeling and get a vote from all of you on this post so we know how to again.
+
+Thomas Steenbergen: Thumbs up, thumbs down.
+
+Sebastian Schuberth: Yes. Is that a problem?
+
+Thomas Steenbergen: Let me see if I can do that.
+
+Martin: On the comment,…
+
+Martin: right? Yeah, on this one. Okay.
+
+Sebastian Schuberth: So is this test voting or is this real voting?
+
+Thomas Steenbergen: No, I votes.
+
+Sebastian Schuberth: Okay.
+
+Thomas Steenbergen: I voted.
+
+Sebastian Schuberth: Then obviously as I myself proposed this. So we have Two more missing votes.
+
+Martin: I need to open the page.
+
+Sebastian Schuberth: So, thanks for voting. now we have the unfortunate situation which is exactly the situation I was afraid to happen that we have a split here with a slight majority in favor of proceeding with this.  So it's not a twothird votes majority I guess but it's a simple majority and I mean this is not covered by any charter or policy rules anyway but since we have a simple majority that is in favor of proceeding with the idea to perform the
+
+### 00:55:00
+
+Sebastian Schuberth: I would at least be willing to invest some more time in clarifying on some of the obstacles.
+
+Marcel Bochtler: Yes, I think the tacle Thomas mentioned that you need to become a member if you want to be a committer a board member or something. I think this is one of the biggest obstacles and this should be clarified and…
+
+Marcel Bochtler: this vote was only for continuing to investigate that if we would have no majority at all, we could stop now.
+
+Sebastian Schuberth: Exactly. Yes.
+
+Marcel Bochtler: But I agree with you here and I think we should clarify on these things. If the votes don't change, then that's it, I guess. But we should clarify at least these potential obstacles. Yes.
+
+Thomas Steenbergen: on the other side. You need to hear both sides.
+
+Sebastian Schuberth: So, let's be very clear about this.
+
+Sebastian Schuberth: At least my goal for this initiative is not to give another chance to help us with the project. They had their chance for almost eight years. That chance is over. So I don't see a point anymore in talking to Mike Dolan or Kate or whoever from the Linux Foundation to give them yet another chance. So this is not the goal of this task.
+
+Sebastian Schuberth: The goal of this task is to definitely initiate the move.
+
+Thomas Steenbergen: I'm just saying it…
+
+Thomas Steenbergen: because so far I've had that all left and not the others. and…
+
+Sebastian Schuberth: Yeah. But the pro that is exactly part of the problem,…
+
+Thomas Steenbergen: we also haven't
+
+Sebastian Schuberth: Thomas. I mean if it's only you who is able to communicate with Linux Foundation about our project that's not a healthy situation to be in for a project that is managed by five people in the TSC right so if you're the funnel that every communication has to go through that's inefficient and probably biased as well. Yeah, but it should exactly be the opposite, right? It should be not us coming to them and begging for building up a relationship and…
+
+Sebastian Schuberth: It should be them supporting us. That's the whole point. Why are we at any foundation at all? Then if we need to always initiate everything and need to care about everything ourselves, what's the purpose of a foundation…
+
+Thomas Steenbergen: But…
+
+Sebastian Schuberth: then in the first That's…
+
+Thomas Steenbergen: but that's exactly the same how things are set up in Eclipse. You get it because Bosch is a team member and you're a member. So that's…
+
+Sebastian Schuberth: what you're claiming.
+
+Thomas Steenbergen: why the thing Yes.
+
+Sebastian Schuberth: But I don't believe that's true. I mean, you do get better support as an Eclipse Foundation project no matter whether you are backed up by a member organization or not. That is my experience.
+
+Sebastian Schuberth: Yeah, we're over time already, but of course I'm curious. so for these two people, Frank and Thomas, who have voted down here, would you like like to shortly and briefly explain what your concerns are with the move or why you dislike the idea? Is it about those obstacles?  Because we have to clarify some things first or is it something else that we should probably document
+
+Thomas Steenbergen: I know how to get things done and I know what kind of stupid monster it can be. But we deliberately didn't do leverage. So I said I think that our chances for project success are higher with our left if we get our own stuff together and I think because they have a bigger marketing machine,…
+
+Thomas Steenbergen: they have more money. Do I think that we need to move outside of ACT which has been the biggest problem in my opinion? Yes, I think we need to move somewhere else. maybe open Z where there are better stronger governance inside of don't believe the ACT is the right place. But they said I think it's fixable but
+
+Sebastian Schuberth: Okay. What about Frank?
+
+Frank Viernau: Yeah. For me the benefits or…
+
+Frank Viernau: the things did not seem too problematic to me. So for example this thing of proactive communication from their side. I would not mind much who initiates communicating. So I do not see much of a problem with this.  And then from the Eclipse Foundation there's this thing about quality and some predefined things and I also do not see which problem on our side this would fix the benefits this would give for example so overall I have the feeling that this thing probably also has some risks or maybe
+
+### 01:00:00
+
+Frank Viernau: it creates some waves and so I would really understand where I would need to see a clearer benefit in order to vote thumbs up for this. Yes.
+
+Sebastian Schuberth: things mentioned here don't convince you as benefits. So then I'm a bit clueless what would convince you. but maybe you can just and any of you of course put additional comments here to the issue ticket. yeah Martin you have raised your hand. Yeah.
+
+Martin: Yeah. Yeah. I just thought maybe not only the down voters could give a summary also the up voters. So my summary would be just that in the history of art after the initiation at here it was exactly one company that really invested in in art and that was Bosch and that company preferred if we would have taken the Eclipse Foundation back then but through the not a single relevant contribution came. So yes, I hear promises for all the time about how it could make networking everything more successful. It could attract anyone but it did not happen for so many years and that's why but the one investment we got I would have preferred Eclipse Foundation and that's …
+
+Sebastian Schuberth: I sell you.
+
+Martin: why I bought did the upload.
+
+Marcel Bochtler: Yeah, I also see now the difference from the foundations I worked with so the Linux foundation or I didn't see anything from that since we initiated the server project. I see that what a foundation can do and I see that these are good things. I a totally agree with the values the Eclipse Foundation has and the rules.
+
+Marcel Bochtler: For example, I like the rule that it's not your role that I don't agree. I'm don't want to say that this is the case in the Linux Foundation, but it's explicitly stated in the Eclipse Foundation that if you are employed by an employer developing an Eclipse Foundation project, this doesn't really matter. You won't become automatically a committer.  And we already have I think two new developers in our team who are developing actively for the old server but they are not committers because they didn't pass the bar yet. and I see that we get support.
+
+Marcel Bochtler: I see what Martin did and how he set up the project and how we are act actively voting how we actually voting for new committers and the whole process is defined and I like this from the Linux Foundation in the years I worked on I have never heard a word so that's why I voted in favor of at least proceeding the investigation if we should move foundations
+
+Sebastian Schuberth: Yeah, thanks for these statements. Yeah, we're like I said over time already and I think we got what at least I wanted to get a feeling from this meeting. So thanks for participating. Feel free to make up your mind again and comment on the issue.  But due to this simple majority voting I would now proceed with reaching out to some people putting you all in any email that I'm writing. So no hidden communication here about how to proceed with this idea and if in the course of action it turns out it's totally unfeasible or involves risk risks that we are not willing to take then we can still abandon this right.
+
+Sebastian Schuberth: this is just about whether it's worth investigating this idea further and the majority vote said yes we are going to investigate this nice final word okay then thanks all for joining Okay,…
+
+### 01:05:00
+
+Marcel Bochtler: One hint, Sebastian, I took some notes. if the Gemini thing was not working, you can contact me. And very unsorted, I need to sort them. But I took some notes while you were speaking and I was speaking others. Yeah.
+
+Sebastian Schuberth: great. Thank you.
+
+Thomas Steenbergen: Yeah. Yeah.
+
+Sebastian Schuberth: Yeah, I find out.
+
+Thomas Steenbergen: Yeah. Can somebody please the not put the notes today somewhere by Monday on the governance thing like in minutes? Hopefully that works.
+
+Thomas Steenbergen: right. I need to run. Sorry.
+
+Sebastian Schuberth: I didn't understand that,…
+
+Martin: Okay, bye.
+
+Sebastian Schuberth: but whatever.
+
+Martin: No, he just asked if we can update the meeting minutes in the governance repository.
+
+Sebastian Schuberth: Okay. Yeah. Yeah. I hope so. maybe it will not be nicely formatted depending on how Gemini took notes but I hope so. Yeah. Yeah. Exactly.
+
+Martin: Frank, do you have a question or…
+
+Frank Viernau: No.
+
+Frank Viernau: Did I indicate or…
+
+Martin: No, you said something. I wasn't sure. Okay. Okay then.
+
+Frank Viernau: I know Bye.
+
+Marcel Bochtler: Okay, see you later.
+
+Marcel Bochtler: Bye. Have a nice day.
+
+### Meeting ended after 01:07:24 👋
+
+*This editable transcript was computer generated and might contain errors. People can also change the text after it was created.*
+


### PR DESCRIPTION
The purpose of this meeting was to discuss the proposal to move the ORT project from the Linux Foundation (LF) to the Eclipse Foundation (EF), see [1].

The Markdown was created by exporting the Google Drive document created by Google Gemini without any modifications. In order to maintain the exact document created by Gemini, any corrections should be done as separate commits on top.

[1]: https://github.com/oss-review-toolkit/ort-governance/issues/35