### PR TITLE
Add meeting minutes for the TSC meeting on 2025-01-17

### DIFF
--- a/minutes/2025-01-17.md
+++ b/minutes/2025-01-17.md
@@ -1,0 +1,83 @@
+# ORT TSC Meeting - 2025-01-17
+
+## Attendees
+- Frank Viernau
+- Marcel Bochtler
+- Martin Nonnenmacher
+- Sebastian Schuberth
+- Thomas Steenbergen
+
+## Agenda
+- Proposal to move the ORT project from the Linux Foundation (LF) to the Eclipse Foundation (EF)
+- Discussion of reasons, pros and cons, and potential obstacles
+- Impact on project roles and contributors
+- Vote on proceeding with the move
+
+## Discussion
+
+**Proposal:**  
+Sebastian proposed moving the ORT project from the LF to the EF. This topic had been discussed previously, but Sebastian requested a formal vote.
+
+**Reasons for the Proposal:**  
+Sebastian cited a lack of activity from the ACT group and referenced ort-governance/issues/35. He presented the content of this issue and highlighted the Scaffold tooling, which is apparently a wrapper for FOSSology and is now promoted by the LF for compliance checks.
+
+**Responses and Comments:**  
+- Thomas noted that there is still funding in the ACT group and that he receives responses from the LF, unlike Sebastian. He clarified that Scaffold is not a tool around FOSSology but is listed to obtain funding.
+- Martin suggested that responsible people should be listed openly; Thomas confirmed that this is already the case.
+- Thomas explained that ORT does not use LF resources because the project is not ready. LF provides funding for the ORT Community Day, but ORT does not use LF marketing due to incomplete documentation.
+- Sebastian clarified that ORT itself is not receiving funding; rather, the Open Chain Tooling group is. He shared that Double Open is now an EF member and that the onboarding experience is much better, although this may not be a fair comparison since Double Open is a paying EF member.
+- Thomas stated that onboarding at LF would be similar for paying members.
+- Martin described his positive experience onboarding the ORT Server project with EF, noting EF's responsiveness and emphasis on quality documentation.
+
+**Pros of the Eclipse Foundation:**
+- EF has shown interest and investment in ORT, intending to use it for their internal CQ process.
+- TSC members have been involved and compensated by EF.
+- Sebastian emphasized that EF is the largest OSS foundation in Europe, is more active and responsive than LF, and has an inherent interest in ORT, which could help grow the community.
+- Moving to EF would unify the Server and ORT projects and better fit the project's technology needs, potentially attracting more developers from EF.
+
+**Additional Comments:**
+- Thomas is working with LF to onboard banks and government projects. He noted that there is no central control or foundation, and projects should choose what best fits their needs.
+- Sebastian agreed that experience with both foundations has been gathered and found LF support lacking.
+- Martin asked Thomas how LF supports ORT. Thomas explained that ORT was built within German automotive, whose members are all EF members, but funding members are dwindling. He believes ORT Server is perceived as a Bosch project, which Sebastian disputed.
+- Sebastian stated that ORT should not be solely associated with SPDX, as it supports other SBOM formats.
+- Thomas noted that different parts of LF are not always aligned.
+- Sebastian reiterated that EF is a better technological fit and mentioned collaboration between Double-Open and nexB/AboutCode in the EU-funded OCCTET project.
+
+**Potential Obstacles:**
+- Transferring the unregistered ORT trademark from LF to EF may be problematic. Sebastian has spoken to people willing to help, but LF may not cooperate.
+- Thomas has discussed this with LF. The TSC, by its charter, is not empowered to move the project; a 2/3 majority (4/5 TSC members) is required to change the charter. LF and the original owners/donators (HERE Technologies) must also approve the move. Thomas doubts HERE will approve.
+
+**Impact on Roles and Contributors:**
+- Frank asked about the impact on committers, project leads, and contributors if the TSC decides to move the project.
+- Martin explained EF's defined roles and processes for adding and removing committers.
+- Frank inquired about requirements for becoming a paying member and whether paying members have more influence. Martin replied that this is not the case.
+- Sebastian noted that one can become a project lead even if not part of an EF member organization.
+- Martin clarified that employment status does not affect EF roles; new employees cannot automatically become committers.
+- Frank asked if there are disadvantages for committers from non-EF member organizations. Thomas said it is different for EF members and that companies must be EF members to commit on their behalf.
+- Sebastian disagreed, stating he committed on behalf of Double Open before it became an EF member. He suggested clarifying whether EF membership is required to contribute on behalf of a company.
+- Frank asked if non-EF members can join the TSC. Sebastian replied that EF does not have a TSC per se.
+- Martin explained that if the community votes for a new committer, the [PMC](https://www.eclipse.org/projects/handbook/#elections-requirements) must agree.
+
+## Decisions
+
+- The TSC held a vote on whether to continue investigating what a move to EF would entail. The result was a 3-2 majority in favor.
+
+**[Voting Result](https://github.com/oss-review-toolkit/ort-governance/issues/35#issuecomment-2598128151):**
+
+| Voted in Favor | Voted Against      |
+|:--------------:|:------------------:|
+| Marcel         | Thomas             |
+| Sebastian      | Frank              |
+| Martin         |                    |
+
+## Comments on the Vote
+
+- Sebastian asked Thomas and Frank, who voted against proceeding, to explain their votes.
+    - Thomas believes LF support could improve if ORT improves its organization.
+    - Frank does not see major issues with LF, dislikes EF's predefined quality goals, sees risks with the move, and wants to evaluate further benefits of moving to EF.
+    - Martin noted that only one company invested in ORT and that LF has not contributed.
+    - Marcel supports the move, citing better maintenance and governance of EF-supported projects.
+
+## Closing
+
+Sebastian thanked the TSC for attending and providing feedback.


### PR DESCRIPTION
The purpose of this meeting was to discuss the proposal to move the ORT project from the Linux Foundation (LF) to the Eclipse Foundation (EF), see [1].

[1]: https://github.com/oss-review-toolkit/ort-governance/issues/35
